### PR TITLE
Add PHONON_INCLUDE_PATH to include_directories()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,7 @@ endif()
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}
                     ${CMAKE_CURRENT_BINARY_DIR}
+                    ${PHONON_INCLUDE_DIR}
 )
 
 add_subdirectory(3rdparty)


### PR DESCRIPTION
Distributions may have phonon includes in any path. For example, in ArchLinux it is `/usr/include/phonon4qt5/phonon`. It would be nice to add `${PHONON_INCLUDE_PATH}` to `CMakeLists.txt`.
